### PR TITLE
Include new parameters (campaign_id, template_id) in event_track with example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,17 @@ Add an event to a user profile:
 $iterable->event_track( 'john@example.com', 'Test Event' );
 ```
 
+Tie user event to a specific campaign
 ```php
 $iterable->event_track( 
-		('john@example.com',
+		'john@example.com',
 		'test event',
 		time(),
-		'iterableEmailCampaignId',
 		array(
 			'some data field' => 'some data field value'
-		)
+		),
+        false,
+		'some campaign id',
 	);
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ Add an event to a user profile:
 $iterable->event_track( 'john@example.com', 'Test Event' );
 ```
 
+```php
+$iterable->event_track( 
+		('john@example.com',
+		'test event',
+		time(),
+		'iterableEmailCampaignId',
+		array(
+			'some data field' => 'some data field value'
+		)
+	);
+```
+
 ### Users
 
 Get a user by email:

--- a/iterable.php
+++ b/iterable.php
@@ -178,7 +178,7 @@ if( !class_exists( 'Iterable' ) ) {
 
         /* Events */
 
-        public function event_track( $email, $event_name, $created_at = false,
+        public function event_track( $email, $event_name, $created_at = false, $iterableEmailCampaignId = false,
             $data_fields = false, $user_id = false ) {
             $request = array(
                 'email' => $email,
@@ -187,7 +187,8 @@ if( !class_exists( 'Iterable' ) ) {
 
             $this->set_optionals( $request, array(
                 'createdAt' => (int) $created_at,
-                'dataFieds' => $data_fields,
+				'campaignId' => (int) $iterableEmailCampaignId,
+                'dataFields' => $data_fields,
                 'user_id' => $user_id
             ) );
 

--- a/iterable.php
+++ b/iterable.php
@@ -178,8 +178,8 @@ if( !class_exists( 'Iterable' ) ) {
 
         /* Events */
 
-        public function event_track( $email, $event_name, $created_at = false, $iterableEmailCampaignId = false,
-            $data_fields = false, $user_id = false ) {
+        public function event_track( $email, $event_name, $created_at = false, $data_fields = false,
+            $user_id = false, $campaign_id = false, $template_id = false ) {
             $request = array(
                 'email' => $email,
                 'eventName' => $event_name,
@@ -187,7 +187,8 @@ if( !class_exists( 'Iterable' ) ) {
 
             $this->set_optionals( $request, array(
                 'createdAt' => (int) $created_at,
-				'campaignId' => (int) $iterableEmailCampaignId,
+		'campaignId' => (int) $campaign_id,
+		'templateId' => (int) $template_id,
                 'dataFields' => $data_fields,
                 'user_id' => $user_id
             ) );

--- a/iterable.php
+++ b/iterable.php
@@ -187,10 +187,10 @@ if( !class_exists( 'Iterable' ) ) {
 
             $this->set_optionals( $request, array(
                 'createdAt' => (int) $created_at,
-		'campaignId' => (int) $campaign_id,
-		'templateId' => (int) $template_id,
                 'dataFields' => $data_fields,
-                'user_id' => $user_id
+                'user_id' => $user_id,
+                'campaignId' => (int) $campaign_id,
+                'templateId' => (int) $template_id,
             ) );
 
             return $this->send_request( 'events/track',


### PR DESCRIPTION
Building on @dillondoyle's pull request but with some additional changes so that it passes unit tests and doesn't break existing uses of the event_track function.
